### PR TITLE
NanoWiki import fix: websites don't have local names

### DIFF
--- a/loom-nm/src/main/java/net/idea/loom/nm/nanowiki/NanoWikiRDFReader.java
+++ b/loom-nm/src/main/java/net/idea/loom/nm/nanowiki/NanoWikiRDFReader.java
@@ -1239,7 +1239,7 @@ class ProcessMaterial extends ProcessSolution {
 		}
 		String homepage = null;
 		try {
-			homepage = qs.get("homepage").asResource().getLocalName();
+			homepage = qs.get("homepage").toString();
 			record.getExternalids().add(
 					new ExternalIdentifier("HOMEPAGE", homepage));
 		} catch (Exception x) {


### PR DESCRIPTION
Nina, I am not sure why the code was extracting the localName part, but I don't think that's correct...
