### PR TITLE
Patch for more round tripping and reading values with errors

### DIFF
--- a/loom-nm/src/main/java/net/idea/loom/nm/nanowiki/ENanoMapperRDFReader.java
+++ b/loom-nm/src/main/java/net/idea/loom/nm/nanowiki/ENanoMapperRDFReader.java
@@ -7,7 +7,6 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -23,7 +22,6 @@ import com.hp.hpl.jena.query.QueryExecutionFactory;
 import com.hp.hpl.jena.query.QueryFactory;
 import com.hp.hpl.jena.query.QuerySolution;
 import com.hp.hpl.jena.query.ResultSet;
-import com.hp.hpl.jena.rdf.model.Literal;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.RDFNode;
@@ -370,6 +368,14 @@ public class ENanoMapperRDFReader extends DefaultIteratingChemObjectReader
 						try {
   						    effect.setLoValue(Double.parseDouble(loHigh[0]));
 						    effect.setUpValue(Double.parseDouble(loHigh[1]));
+						} catch (Exception x) {
+							effect.setTextValue(valueLit);
+						}
+					} else if (valueLit.contains("±")) {
+						String[] leHigh = valueLit.split("±");
+						try {
+  						    effect.setLoValue(Double.parseDouble(leHigh[0]));
+						    effect.setErrorValue(Double.parseDouble(leHigh[1]));
 						} catch (Exception x) {
 							effect.setTextValue(valueLit);
 						}

--- a/loom-nm/src/main/resources/net/idea/loom/nm/enmrdf/bundles_all.sparql
+++ b/loom-nm/src/main/resources/net/idea/loom/nm/enmrdf/bundles_all.sparql
@@ -1,22 +1,14 @@
 #all bundles
-PREFIX afn: <http://jena.hpl.hp.com/ARQ/function#>
-PREFIX fn: <http://www.w3.org/2005/xpath-functions#>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX time: <http://www.w3.org/2006/time#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX mw: <http://127.0.0.1/mediawiki/index.php/Special:URIResolver/>
-PREFIX w: <http://semantic-mediawiki.org/swivt/1.0#>
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX pav: <http://purl.org/pav/>
 
-
-SELECT distinct  ?b ?date ?status ?purpose ?source ?label
+SELECT DISTINCT ?b ?description ?label ?license ?publisher
 WHERE {
-   ?m rdf:type mw:Category-3AMaterials.
-   ?m mw:Property-3AHas_Bundle ?b.
-   OPTIONAL {?b w:wikiPageModificationDate ?date.}
-   OPTIONAL {?b mw:Property-3AHas_Status ?status.}
-   OPTIONAL {?b mw:Property-3AHas_Purpose ?purpose.}
-   OPTIONAL {?b mw:Property-3AHas_Source ?source_r. ?source_r rdfs:label ?source.}
-   OPTIONAL {?b rdfs:label ?label.}
+   ?b rdf:type void:Dataset .
+   OPTIONAL { ?b dcterms:title ?label . }
+   OPTIONAL { ?b dcterms:license ?license . }
+   OPTIONAL { ?b dcterms:description ?description . }
+   OPTIONAL { ?b dcterms:publisher ?publisher . }
 }

--- a/loom-nm/src/main/resources/net/idea/loom/nm/enmrdf/m_materialprops.sparql
+++ b/loom-nm/src/main/resources/net/idea/loom/nm/enmrdf/m_materialprops.sparql
@@ -12,9 +12,7 @@ WHERE {
   BIND (<%s> AS ?material)
   ?material dcterms:type ?type .
   OPTIONAL { ?material rdfs:label ?label . }
-  OPTIONAL {
-    ?material dcterms:source/dcterms:title ?owner .
-  }
+  OPTIONAL { ?material dcterms:source ?owner . }
   OPTIONAL { ?material owl:sameAs ?sameAs . }
   OPTIONAL { ?material skos:closeMatch ?closeMatch . }
   OPTIONAL { ?material skos:relatedMatch ?relatedMatch . }


### PR DESCRIPTION
Besides some code management, this patch add roundtripping of license, publisher, and description, effectively supporting now this:

```turtle
owner:DEMO-6eb881ab-36f4-3a24-96b8-caf2ea920915
        a                    void:Dataset ;
        dcterms:description  "Data extracted from abstracts from the 2nd NanoSafety Forum for Young Scientists Data." ;
        dcterms:license      <https://creativecommons.org/publicdomain/zero/1.0/> ;
        dcterms:publisher    "Egon Willighagen" ;
        dcterms:title        "2nd NanoSafety Forum for Young Scientists Data" .
```

This patch goes hands-in-hand with https://github.com/ideaconsult/ambit-mirror/pull/2